### PR TITLE
Fixing help popup covering company popup

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -116,10 +116,12 @@ just grab the first candidate and press forward."
   (let* ((selected (nth company-selection company-candidates))
          (doc (company-quickhelp--doc selected))
          (ovl company-pseudo-tooltip-overlay)
+         (overlay-width (* (frame-char-width) (if ovl (overlay-get ovl 'company-width) 0)))
+         (overlay-position (* (frame-char-width) (- (if ovl (overlay-get ovl 'company-column) 1) 1)))
          (x-gtk-use-system-tooltips nil))
     (when (and ovl doc)
       (with-no-warnings
-        (pos-tip-show doc nil (overlay-start ovl) nil 300 80 nil nil 1)))))
+        (pos-tip-show doc nil (overlay-start ovl) nil 300 80 nil (+ overlay-width overlay-position) 1)))))
 
 (defun company-quickhelp--set-timer ()
   (when (null company-quickhelp--timer)


### PR DESCRIPTION
Hi, I was having the same issue as #18.

In this pull request, the `company-quickhelp--show` function was changed to prevent the help popup from covering up the company completions list.

Before:
![before](https://cloud.githubusercontent.com/assets/4155393/8693496/8ef43126-2aa5-11e5-8e50-46ff31b692af.png)

After:
![after](https://cloud.githubusercontent.com/assets/4155393/8693497/92d0a054-2aa5-11e5-9886-d74904eaeee7.png)
