### PR TITLE
Check for doc buffer not beeing nil

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -120,7 +120,8 @@ just grab the first candidate and press forward."
   (cl-letf (((symbol-function 'completing-read)
              #'company-quickhelp--completing-read))
     (let* ((doc (company-call-backend 'doc-buffer selected))
-           (doc-and-meta (company-quickhelp--doc-and-meta doc))
+           (doc-and-meta (when doc
+                           (company-quickhelp--doc-and-meta doc)))
            (truncated (plist-get doc-and-meta :truncated))
            (doc (plist-get doc-and-meta :doc)))
       (unless (string= doc "")


### PR DESCRIPTION
In commit 5a3f2377bf87765e09023bc5835fd8601cc1a7cb the check for the doc buffer is `nil` has been removed, which causes the following error coming from `with-current-buffer` with a `nil` as argument:

```
Error running timer ‘company-quickhelp--show’: (wrong-type-argument stringp nil)
```

This patch adds back the check since `(company-call-backend 'doc-buffer selected)` can return nil
