### PR TITLE
Use cl-lib macro instead of cl.el for a byte-compile warning

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -38,6 +38,7 @@
 ;;; Code:
 (require 'company)
 (require 'pos-tip)
+(require 'cl-lib)
 
 (defgroup company-quickhelp nil
   "Documentation popups for `company-mode'"
@@ -114,7 +115,7 @@ be triggered manually using `company-quickhelp-show'."
   "`cider', and probably other libraries, prompt the user to
 resolve ambiguous documentation requests.  Instead of failing we
 just grab the first candidate and press forward."
-  (first candidates))
+  (car candidates))
 
 (defun company-quickhelp--doc (selected)
   (cl-letf (((symbol-function 'completing-read)


### PR DESCRIPTION
And load cl-lib.el explicitly. A byte-compile warning is as below.

```
company-quickhelp.el:209:1:Warning: the function `first' is not known to be defined
```
