### PR TITLE
Fix setting nil to company-tooltip-minimum-width issue

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -68,7 +68,7 @@ be triggered manually using `company-quickhelp-show'."
 (defvar company-quickhelp--timer nil
   "Quickhelp idle timer.")
 
-(defvar company-quickhelp--original-tooltip-width nil
+(defvar company-quickhelp--original-tooltip-width company-tooltip-minimum-width
   "The documentation popup breaks inexplicably when we transition
   from a large pseudo-tooltip to a small one.  We solve this by
   overriding `company-tooltip-minimum-width' and save the


### PR DESCRIPTION
User calls '(company-quickhelp-mode -1)' when company-quickhelp-mode
is disabled, then company-tooltip-minimum-width is nil. This causes
some errors because its type must be integer.

This is related to https://github.com/syl20bnr/spacemacs/issues/4945
