### PR TITLE
Abandon documentation display as soon as user inputs

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -160,39 +160,40 @@ currently active `company' completion candidate."
   (unless (company-quickhelp-pos-tip-available-p)
     (error "company-quickhelp is not available in this emacs version or frame"))
   (company-quickhelp--cancel-timer)
-  (let* ((selected (nth company-selection company-candidates))
-         (doc (company-quickhelp--doc selected))
-         (width 80)
-         (timeout 300)
-         (ovl company-pseudo-tooltip-overlay)
-         (overlay-width (* (frame-char-width)
-                           (if ovl (overlay-get ovl 'company-width) 0)))
-         (overlay-position (* (frame-char-width)
-                              (- (if ovl (overlay-get ovl 'company-column) 1) 1)))
-         (x-gtk-use-system-tooltips nil)
-         (fg-bg `(,company-quickhelp-color-foreground
-                  . ,company-quickhelp-color-background)))
-    (when (and ovl doc)
-      (with-no-warnings
-        (if company-quickhelp-use-propertized-text
-            (let* ((frame (window-frame (selected-window)))
-                   (max-width (pos-tip-x-display-width frame))
-                   (max-height (pos-tip-x-display-height frame))
-                   (w-h (pos-tip-string-width-height doc)))
-              (cond
-               ((> (car w-h) width)
-                (setq doc (pos-tip-fill-string doc width nil 'none nil max-height)
-                      w-h (pos-tip-string-width-height doc)))
-               ((or (> (car w-h) max-width)
-                    (> (cdr w-h) max-height))
-                (setq doc (pos-tip-truncate-string doc max-width max-height)
-                      w-h (pos-tip-string-width-height doc))))
-              (pos-tip-show-no-propertize doc fg-bg (overlay-start ovl) nil timeout
-                                          (pos-tip-tooltip-width (car w-h) (frame-char-width frame))
-                                          (pos-tip-tooltip-height (cdr w-h) (frame-char-height frame) frame)
-                                          nil (+ overlay-width overlay-position) 1))
-          (pos-tip-show doc fg-bg (overlay-start ovl) nil timeout width nil
-                        (+ overlay-width overlay-position) 1))))))
+  (while-no-input
+    (let* ((selected (nth company-selection company-candidates))
+           (doc (company-quickhelp--doc selected))
+           (width 80)
+           (timeout 300)
+           (ovl company-pseudo-tooltip-overlay)
+           (overlay-width (* (frame-char-width)
+                             (if ovl (overlay-get ovl 'company-width) 0)))
+           (overlay-position (* (frame-char-width)
+                                (- (if ovl (overlay-get ovl 'company-column) 1) 1)))
+           (x-gtk-use-system-tooltips nil)
+           (fg-bg `(,company-quickhelp-color-foreground
+                    . ,company-quickhelp-color-background)))
+      (when (and ovl doc)
+        (with-no-warnings
+          (if company-quickhelp-use-propertized-text
+              (let* ((frame (window-frame (selected-window)))
+                     (max-width (pos-tip-x-display-width frame))
+                     (max-height (pos-tip-x-display-height frame))
+                     (w-h (pos-tip-string-width-height doc)))
+                (cond
+                 ((> (car w-h) width)
+                  (setq doc (pos-tip-fill-string doc width nil 'none nil max-height)
+                        w-h (pos-tip-string-width-height doc)))
+                 ((or (> (car w-h) max-width)
+                      (> (cdr w-h) max-height))
+                  (setq doc (pos-tip-truncate-string doc max-width max-height)
+                        w-h (pos-tip-string-width-height doc))))
+                (pos-tip-show-no-propertize doc fg-bg (overlay-start ovl) nil timeout
+                                            (pos-tip-tooltip-width (car w-h) (frame-char-width frame))
+                                            (pos-tip-tooltip-height (cdr w-h) (frame-char-height frame) frame)
+                                            nil (+ overlay-width overlay-position) 1))
+            (pos-tip-show doc fg-bg (overlay-start ovl) nil timeout width nil
+                          (+ overlay-width overlay-position) 1)))))))
 
 (defun company-quickhelp--set-timer ()
   (when (null company-quickhelp--timer)


### PR DESCRIPTION
Without this Emacs freezes momentarily if the documentation being displayed is
large or the company-backend takes time to fetch documentation, causing user
input to be blocked.

'while-no-input' aborts body as soon as user input arrives
