### PR TITLE
Add support for 'quickhelp-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ You might also want to put this in your `init.el`:
 ```el
 (eval-after-load 'company
   '(define-key company-active-map (kbd "C-c h") #'company-quickhelp-manual-begin))
-
 ```
 
 This gives you a key to manually trigger the help popup, but only when
 company is doing its thing.
+
+## Developer corner
+
+By default, `company-quickhelp` displays the contents of the buffer returned by a `doc-buffer` backend call.  To override this default, backends should respond to the `quickhelp-string` command with a string to display instead of the contents of `doc-buffer`.
 
 ## Is it any good?
 

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -102,8 +102,9 @@ be triggered manually using `company-quickhelp-show'."
   (let ((doc-buffer (if (consp doc) (car doc) doc))
         (doc-begin (when (consp doc) (cdr doc))))
     (with-current-buffer doc-buffer
+      (setq doc-begin (or doc-begin (point-min)))
       (let ((truncated t))
-        (goto-char (or doc-begin (point-min)))
+        (goto-char doc-begin)
         (if company-quickhelp-max-lines
             (forward-line company-quickhelp-max-lines)
           (goto-char (point-max)))
@@ -119,7 +120,7 @@ be triggered manually using `company-quickhelp-show'."
                      (looking-at-p "\\[source\\]")
                      (looking-at-p "^\\s-*$")))
           (forward-line -1))
-        (list :doc (buffer-substring-no-properties (point-min) (point-at-eol))
+        (list :doc (buffer-substring-no-properties doc-begin (point-at-eol))
               :truncated truncated)))))
 
 (defun company-quickhelp--completing-read (prompt candidates &rest rest)

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -113,20 +113,14 @@ be triggered manually using `company-quickhelp-show'."
       (forward-line company-quickhelp-max-lines)
     (goto-char (point-max))))
 
-(defun company-quickhelp--doc-and-meta (doc)
-  ;; The company backend can either return a buffer with the doc or a
-  ;; cons containing the doc buffer and a position at which to start
-  ;; reading.
-  (let ((doc-buffer (if (consp doc) (car doc) doc))
-        (doc-begin (when (consp doc) (cdr doc))))
-    (with-current-buffer doc-buffer
-      (setq doc-begin (or doc-begin (point-min)))
-      (goto-char doc-begin)
-      (company-quickhelp--goto-max-line)
-      (let ((truncated (< (point-at-eol) (point-max))))
-        (company-quickhelp--skip-footers-backwards)
-        (list :doc (buffer-substring-no-properties doc-begin (point-at-eol))
-              :truncated truncated)))))
+(defun company-quickhelp--docstring-from-buffer (start)
+  "Fetch docstring from START."
+  (goto-char start)
+  (company-quickhelp--goto-max-line)
+  (let ((truncated (< (point-at-eol) (point-max))))
+    (company-quickhelp--skip-footers-backwards)
+    (list :doc (buffer-substring-no-properties start (point-at-eol))
+          :truncated truncated)))
 
 (defun company-quickhelp--completing-read (prompt candidates &rest rest)
   "`cider', and probably other libraries, prompt the user to
@@ -134,15 +128,30 @@ resolve ambiguous documentation requests.  Instead of failing we
 just grab the first candidate and press forward."
   (car candidates))
 
+(defun company-quickhelp--fetch-docstring (backend)
+  "Fetch docstring from BACKEND."
+  (let ((quickhelp-str (company-call-backend 'quickhelp-string backend)))
+    (if (stringp quickhelp-str)
+        (with-temp-buffer
+          (insert quickhelp-str)
+          (company-quickhelp--docstring-from-buffer (point-min)))
+      (let ((doc (company-call-backend 'doc-buffer backend)))
+        (when doc
+          ;; The company backend can either return a buffer with the doc or a
+          ;; cons containing the doc buffer and a position at which to start
+          ;; reading.
+          (let ((doc-buffer (if (consp doc) (car doc) doc))
+                (doc-begin (when (consp doc) (cdr doc))))
+            (with-current-buffer doc-buffer
+              (company-quickhelp--docstring-from-buffer (or doc-begin (point-min))))))))))
+
 (defun company-quickhelp--doc (selected)
   (cl-letf (((symbol-function 'completing-read)
              #'company-quickhelp--completing-read))
-    (let* ((doc (company-call-backend 'doc-buffer selected))
-           (doc-and-meta (when doc
-                           (company-quickhelp--doc-and-meta doc)))
+    (let* ((doc-and-meta (company-quickhelp--fetch-docstring selected))
            (truncated (plist-get doc-and-meta :truncated))
            (doc (plist-get doc-and-meta :doc)))
-      (unless (string= doc "")
+      (unless (member doc '(nil ""))
         (if truncated
             (concat doc "\n\n[...]")
           doc)))))


### PR DESCRIPTION
As discussed in #28 :)

I also took that opportunity to fix the support for `cons` returned by doc-buffer (`company-quickhelp` was ignoring the starting offset returned by the backend), but let me know if that should be a separate PR.