### PR TITLE
Fixed a typo

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -29,7 +29,7 @@
 ;; candidate will pop up after `company-quickhelp-idle-delay' seconds.
 
 ;;; Usage:
-;;  put (company-quickhelp-mode 1) in your init.el to activate
+;;  put (company-quickhelp-mode) in your init.el to activate
 ;;  `company-quickhelp-mode'.
 
 ;; You can adjust the time it takes for the documentation to pop up by


### PR DESCRIPTION
Hello:

In #76 , I once said this problem and you changed the instruction in the README.

Now I change `(company-quickhelp 1)` to `(company-quickhelp)` everywhere.