### PR TITLE
Fixed pos-tip position relative to line numbers

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -185,7 +185,8 @@ currently active `company' completion candidate."
                                (if ovl (overlay-get ovl 'company-width) 0)))
              (overlay-position (* (frame-char-width)
                                   (+ (- (if ovl (overlay-get ovl 'company-column) 1) 1)
-                                     (line-number-display-width) 2)))
+                                     (when (bound-and-true-p display-line-numbers)
+                                       (+ (line-number-display-width) 2)))))
              (x-gtk-use-system-tooltips nil)
              (fg-bg `(,company-quickhelp-color-foreground
                       . ,company-quickhelp-color-background)))

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -185,8 +185,8 @@ currently active `company' completion candidate."
                                (if ovl (overlay-get ovl 'company-width) 0)))
              (overlay-position (* (frame-char-width)
                                   (+ (- (if ovl (overlay-get ovl 'company-column) 1) 1)
-                                     (when (bound-and-true-p display-line-numbers)
-                                       (+ (line-number-display-width) 2)))))
+                                     (if (bound-and-true-p display-line-numbers)
+                                       (+ (line-number-display-width) 2) 0))))
              (x-gtk-use-system-tooltips nil)
              (fg-bg `(,company-quickhelp-color-foreground
                       . ,company-quickhelp-color-background)))

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -40,6 +40,9 @@
 (require 'pos-tip)
 (require 'cl-lib)
 
+;; To avoid warnings in Emacs < 26.
+(declare-function line-number-display-width "indent.c")
+
 (defgroup company-quickhelp nil
   "Documentation popups for `company-mode'"
   :group 'company)

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -184,7 +184,8 @@ currently active `company' completion candidate."
              (overlay-width (* (frame-char-width)
                                (if ovl (overlay-get ovl 'company-width) 0)))
              (overlay-position (* (frame-char-width)
-                                  (- (if ovl (overlay-get ovl 'company-column) 1) 1)))
+                                  (+ (- (if ovl (overlay-get ovl 'company-column) 1) 1)
+                                     (line-number-display-width) 2)))
              (x-gtk-use-system-tooltips nil)
              (fg-bg `(,company-quickhelp-color-foreground
                       . ,company-quickhelp-color-background)))


### PR DESCRIPTION
Added offset determined by the presence (or absence) of line-numbers. The errand 2 is the number of columns that line numbers occupy including the current line-number width, as in `█nnn█`. The two ascii blocks are the two extra columns, for a total of 3+2=5 width.

This fixes #96 