### PR TITLE
Added 'company-quickhelp-face' and doc propertization

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -47,6 +47,16 @@
   "Documentation popups for `company-mode'"
   :group 'company)
 
+(defgroup company-quickhelp-faces nil
+  "The faces of `company-quickhelp'."
+  :group 'company-quickhelp
+  :group 'faces)
+
+(defface company-quickhelp-face
+  '((t (:inherit tooltip)))
+  "Face used for displaying the tooltip."
+  :group 'company-quickhelp-faces)
+
 (defcustom company-quickhelp-use-propertized-text nil
   "Allow the text to have properties like color, font size, etc."
   :type '(choice (boolean :tag "Allow"))
@@ -189,7 +199,7 @@ currently active `company' completion candidate."
              (overlay-position (* (frame-char-width)
                                   (+ (- (if ovl (overlay-get ovl 'company-column) 1) 1)
                                      (if (bound-and-true-p display-line-numbers)
-                                       (+ (line-number-display-width) 2) 0))))
+                                         (+ (line-number-display-width) 2) 0))))
              (x-gtk-use-system-tooltips nil)
              (fg-bg `(,company-quickhelp-color-foreground
                       . ,company-quickhelp-color-background)))
@@ -208,16 +218,17 @@ currently active `company' completion candidate."
                         (> (cdr w-h) max-height))
                     (setq doc (pos-tip-truncate-string doc max-width max-height)
                           w-h (pos-tip-string-width-height doc))))
-                  (pos-tip-show-no-propertize doc fg-bg (overlay-start ovl) nil timeout
-                                              (pos-tip-tooltip-width (car w-h) (frame-char-width frame))
-                                              (pos-tip-tooltip-height (cdr w-h) (frame-char-height frame) frame)
-                                              nil (+ overlay-width overlay-position) 1))
+                  (let* ((str (propertize doc 'face 'company-quickhelp-face)))
+                    (pos-tip-show-no-propertize str fg-bg (overlay-start ovl) nil timeout
+                                                (pos-tip-tooltip-width (car w-h) (frame-char-width frame))
+                                                (pos-tip-tooltip-height (cdr w-h) (frame-char-height frame) frame)
+                                                nil (+ overlay-width overlay-position) 1)))
               (pos-tip-show doc fg-bg (overlay-start ovl) nil timeout width nil
                             (+ overlay-width overlay-position) 1))))))))
 
 (defun company-quickhelp--set-timer ()
   (when (or (null company-quickhelp--timer)
-        (eq this-command #'company-quickhelp-manual-begin))
+            (eq this-command #'company-quickhelp-manual-begin))
     (setq company-quickhelp--timer
           (run-with-idle-timer company-quickhelp-delay nil
                                'company-quickhelp--show))))

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -218,22 +218,12 @@ currently active `company' completion candidate."
                         (> (cdr w-h) max-height))
                     (setq doc (pos-tip-truncate-string doc max-width max-height)
                           w-h (pos-tip-string-width-height doc))))
-                  (let* ((w-h (pos-tip-string-width-height doc))
-                         (str (propertize doc 'face 'company-quickhelp-face)))
-                    (pos-tip-show-no-propertize str ;; inconsequential
-                                                fg-bg ;; inconsequential
-                                                (overlay-start ovl) ;; makes the overlay start on the left side of the screen
-                                                nil ;; inconsequential
-                                                timeout ;; inconsequential
+                  (let* ((str (propertize doc 'face 'company-quickhelp-face)))
+                    (pos-tip-show-no-propertize str fg-bg (overlay-start ovl) nil timeout
                                                 (pos-tip-tooltip-width (car w-h) (window-font-width nil 'company-quickhelp-face))
-                                                ;; FIXME: height is not calculated well, or at least,
-                                                ;; it is well calculated, but generally text is truncated too short
-                                                ;;(pos-tip-tooltip-height (cdr w-h) 14)
+                                                ;;(pos-tip-tooltip-height (cdr w-h) (window-font-height nil 'company-quickhelp-face) frame) ;; height generally truncated short
                                                 nil ;; dummy height for testing
-                                                nil ;; inconsequential
-                                                (+ overlay-width overlay-position) ;; puts the overlay right next to the company tooltip
-                                                1 ;; quirk, the overlay-start is 1 y pos lower than needed
-                                                )))
+                                                nil (+ overlay-width overlay-position) 1)))
               (pos-tip-show doc fg-bg (overlay-start ovl) nil timeout width nil
                             (+ overlay-width overlay-position) 1))))))))
 

--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -218,13 +218,29 @@ currently active `company' completion candidate."
                         (> (cdr w-h) max-height))
                     (setq doc (pos-tip-truncate-string doc max-width max-height)
                           w-h (pos-tip-string-width-height doc))))
-                  (let* ((str (propertize doc 'face 'company-quickhelp-face)))
-                    (pos-tip-show-no-propertize str fg-bg (overlay-start ovl) nil timeout
-                                                (pos-tip-tooltip-width (car w-h) (frame-char-width frame))
-                                                (pos-tip-tooltip-height (cdr w-h) (frame-char-height frame) frame)
-                                                nil (+ overlay-width overlay-position) 1)))
+                  (let* ((w-h (pos-tip-string-width-height doc))
+                         (str (propertize doc 'face 'company-quickhelp-face)))
+                    (pos-tip-show-no-propertize str ;; inconsequential
+                                                fg-bg ;; inconsequential
+                                                (overlay-start ovl) ;; makes the overlay start on the left side of the screen
+                                                nil ;; inconsequential
+                                                timeout ;; inconsequential
+                                                (pos-tip-tooltip-width (car w-h) (window-font-width nil 'company-quickhelp-face))
+                                                ;; FIXME: height is not calculated well, or at least,
+                                                ;; it is well calculated, but generally text is truncated too short
+                                                ;;(pos-tip-tooltip-height (cdr w-h) 14)
+                                                nil ;; dummy height for testing
+                                                nil ;; inconsequential
+                                                (+ overlay-width overlay-position) ;; puts the overlay right next to the company tooltip
+                                                1 ;; quirk, the overlay-start is 1 y pos lower than needed
+                                                )))
               (pos-tip-show doc fg-bg (overlay-start ovl) nil timeout width nil
                             (+ overlay-width overlay-position) 1))))))))
+
+(defun company-quickhelp--string-height (string)
+  (with-temp-buffer
+    (insert string)
+    (how-many "\n")))
 
 (defun company-quickhelp--set-timer ()
   (when (or (null company-quickhelp--timer)


### PR DESCRIPTION
The same as #103, but this time with much more conservative changes.

Looks like, as you told me, pos-tip handles the repositioning of the tooltip. So we should either file a bug to pos-tip or handle it ourselves.