### PR TITLE
Fix timer cancellation with company-tng-mode

### DIFF
--- a/company-quickhelp.el
+++ b/company-quickhelp.el
@@ -173,9 +173,9 @@ currently active `company' completion candidate."
     (pos-tip-hide)))
 
 (defun company-quickhelp--show ()
+  (company-quickhelp--cancel-timer)
   (when (and (company-quickhelp-pos-tip-available-p)
              company-selection)
-    (company-quickhelp--cancel-timer)
     (while-no-input
       (let* ((selected (nth company-selection company-candidates))
              (doc (let ((inhibit-message t))


### PR DESCRIPTION
Hi,
I figured that the tooltip overlay isn't shown after the configured delay when using `company-tng-mode`.
That happens bacause in `company-quickhelp--show`,  `company-selection` is  *not* set when you haven't moved to one of the candidates, and so `company-quickhelp--cancel-timer` isn't called and successive calls to `company-quickhelp--set-timer` will not run another timer, cause the condition `(null company-quickhelp--timer)` is not satisfied.
Cancelling the timer regardless of the `company-selection` value fixes the issue.

To test:

```
;; assuming you already have company setup
(company-tng-mode)
(company-quickhelp-mode +1)
;; try to complete something
```
Thanks for reading and for the work on this package.
